### PR TITLE
Fix some minor problems in Package.swift.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.0
 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,7 +33,8 @@ let package = Package(
     .target(name: "OAuth1",
             dependencies: ["CryptoSwift", "TinyHTTPServer"]),
     .target(name: "OAuth2",
-            dependencies: ["CryptoSwift", "TinyHTTPServer", "BigInt", "SwiftyBase64"]),
+            dependencies: ["CryptoSwift", "TinyHTTPServer", "BigInt", "SwiftyBase64"],
+            exclude: ["FirebaseFunctionTokenProvider"]),
     .target(name: "TinyHTTPServer",
 	    dependencies: ["NIO", "NIOHTTP1"]),
     .target(name: "SwiftyBase64"),
@@ -43,9 +44,5 @@ let package = Package(
     .target(name: "Meetup",      dependencies: ["OAuth2"], path: "Sources/Examples/Meetup"),
     .target(name: "Spotify",     dependencies: ["OAuth2"], path: "Sources/Examples/Spotify"),
     .target(name: "Twitter",     dependencies: ["OAuth1"], path: "Sources/Examples/Twitter"),
-  ],
-  exclude: [
-    .exclude(name: "FirebaseFunctionTokenProvider", dependencies: ["OAuth2"], path:
-        "Sources/OAuth2/FirebaseFunctionTokenProvider"),
-    ]
+  ]
 )


### PR DESCRIPTION
Back up to Swift Tools 5.0.
Rework FirebaseFunctionTokenProvider exclusion to work with Swift Tools 5.0.