### PR TITLE
Add Travis CI configuration.

### DIFF
--- a/.travis-install.sh
+++ b/.travis-install.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+#
+# Copyright 2019, Google LLC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# Install dependencies that aren't available as Ubuntu packages (or already present on macOS).
+#
+# Everything goes into $HOME/local.
+#
+# Scripts should add
+# - $HOME/local/bin to PATH
+# - $HOME/local/lib to LD_LIBRARY_PATH
+#
+
+cd
+mkdir -p local
+
+if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+  echo "Using installed Swift tools."
+else
+  echo "Using downloaded Swift tools."
+  # Install swift
+  SWIFT_URL=https://swift.org/builds/swift-5.0-release/ubuntu1404/swift-5.0-RELEASE/swift-5.0-RELEASE-ubuntu14.04.tar.gz
+  echo $SWIFT_URL
+  curl -fSsL $SWIFT_URL -o swift.tar.gz
+  tar -xzf swift.tar.gz --strip-components=2 --directory=local
+fi
+
+# Verify installation
+find local

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,54 @@
+#  
+# Copyright 2019, Google LLC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+os:
+  - linux
+  - osx
+
+cache:
+  apt: true
+  directories:
+    - .build/checkouts
+    - .build/repositories
+
+# Use Ubuntu 14.04
+dist: trusty
+
+osx_image: xcode10.2
+
+sudo: false
+
+addons:
+  apt:
+    packages:
+      - clang-3.8
+      - lldb-3.8
+      - libicu-dev
+      - libtool
+      - libcurl4-openssl-dev
+      - libbsd-dev
+      - build-essential
+      - libssl-dev
+      - uuid-dev
+      - curl
+      - unzip
+
+install: ./.travis-install.sh
+
+script:
+  - echo -en 'travis_fold:start:script.environment\\r' && export PATH=$HOME/local/bin:$PATH && export LD_LIBRARY_PATH=$HOME/local/lib && echo -en 'travis_fold:end:script.environment\\r'
+  - echo -en 'travis_fold:start:swift.resolve-deps\\r' && swift package -v resolve && echo -en 'travis_fold:end:swift.resolve-deps\\r'
+  - echo -en 'travis_fold:start:make.all\\r' && make all && echo -en 'travis_fold:end:make.all\\r'

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/googleapis/google-auth-library-swift.svg?branch=master)](https://travis-ci.org/googleapis/google-auth-library-swift)
+
 # Auth Library for Swift
 
 This project contains Swift packages that can be used to write command-line


### PR DESCRIPTION
As a first step to resolving #17, this commit adds CI configuration that verifies Swift Package Manager builds on Linux and OSX.