### PR TITLE
add import FoundationNetworking

### DIFF
--- a/Sources/OAuth2/BrowserTokenProvider.swift
+++ b/Sources/OAuth2/BrowserTokenProvider.swift
@@ -16,6 +16,7 @@ import Foundation
 import Dispatch
 import TinyHTTPServer
 import NIOHTTP1
+import FoundationNetworking
 
 struct Credentials : Codable {
   let clientID : String

--- a/Sources/OAuth2/BrowserTokenProvider.swift
+++ b/Sources/OAuth2/BrowserTokenProvider.swift
@@ -16,8 +16,9 @@ import Foundation
 import Dispatch
 import TinyHTTPServer
 import NIOHTTP1
+#if os(Linux) && swift(>=5.1)
 import FoundationNetworking
-
+#endif
 struct Credentials : Codable {
   let clientID : String
   let clientSecret : String

--- a/Sources/OAuth2/Connection.swift
+++ b/Sources/OAuth2/Connection.swift
@@ -15,7 +15,9 @@
 import Foundation
 import Dispatch
 import CryptoSwift
+#if os(Linux) && swift(>=5.1)
 import FoundationNetworking
+#endif
 
 public class Connection {
   public var provider: TokenProvider

--- a/Sources/OAuth2/Connection.swift
+++ b/Sources/OAuth2/Connection.swift
@@ -15,6 +15,7 @@
 import Foundation
 import Dispatch
 import CryptoSwift
+import FoundationNetworking
 
 public class Connection {
   public var provider: TokenProvider

--- a/Sources/OAuth2/GoogleCloudMetadataTokenProvider.swift
+++ b/Sources/OAuth2/GoogleCloudMetadataTokenProvider.swift
@@ -14,6 +14,7 @@
 
 import Foundation
 import Dispatch
+import FoundationNetworking
 
 public class GoogleCloudMetadataTokenProvider : TokenProvider {
   public func withToken(_ callback: @escaping (Token?, Error?) -> Void) throws {

--- a/Sources/OAuth2/GoogleCloudMetadataTokenProvider.swift
+++ b/Sources/OAuth2/GoogleCloudMetadataTokenProvider.swift
@@ -14,7 +14,9 @@
 
 import Foundation
 import Dispatch
+#if os(Linux) && swift(>=5.1)
 import FoundationNetworking
+#endif
 
 public class GoogleCloudMetadataTokenProvider : TokenProvider {
   public func withToken(_ callback: @escaping (Token?, Error?) -> Void) throws {

--- a/Sources/OAuth2/ServiceAccountTokenProvider/ServiceAccountTokenProvider.swift
+++ b/Sources/OAuth2/ServiceAccountTokenProvider/ServiceAccountTokenProvider.swift
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 import Foundation
+#if os(Linux) && swift(>=5.1)
 import FoundationNetworking
+#endif
 
 struct ServiceAccountCredentials : Codable {
   let CredentialType : String

--- a/Sources/OAuth2/ServiceAccountTokenProvider/ServiceAccountTokenProvider.swift
+++ b/Sources/OAuth2/ServiceAccountTokenProvider/ServiceAccountTokenProvider.swift
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import Foundation
+import FoundationNetworking
 
 struct ServiceAccountCredentials : Codable {
   let CredentialType : String


### PR DESCRIPTION
For Swift 5.1 compatibility on Linux, some functions have been moved into a framework called `FoundationNetworking`.