### PR TITLE
Support Swift 5.1 on Linux

### DIFF
--- a/Sources/OAuth1/BrowserTokenProvider.swift
+++ b/Sources/OAuth1/BrowserTokenProvider.swift
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 import Dispatch
 import CryptoSwift
 import TinyHTTPServer

--- a/Sources/OAuth1/Connection.swift
+++ b/Sources/OAuth1/Connection.swift
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 import Dispatch
 import CryptoSwift
 

--- a/Sources/OAuth2/BrowserTokenProvider.swift
+++ b/Sources/OAuth2/BrowserTokenProvider.swift
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 import Dispatch
 import TinyHTTPServer
 import NIOHTTP1

--- a/Sources/OAuth2/Connection.swift
+++ b/Sources/OAuth2/Connection.swift
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 import Dispatch
 import CryptoSwift
 

--- a/Sources/OAuth2/GoogleCloudMetadataTokenProvider.swift
+++ b/Sources/OAuth2/GoogleCloudMetadataTokenProvider.swift
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 import Dispatch
 
 public class GoogleCloudMetadataTokenProvider : TokenProvider {

--- a/Sources/OAuth2/ServiceAccountTokenProvider/ServiceAccountTokenProvider.swift
+++ b/Sources/OAuth2/ServiceAccountTokenProvider/ServiceAccountTokenProvider.swift
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 struct ServiceAccountCredentials : Codable {
   let CredentialType : String


### PR DESCRIPTION
On Linux in Swift 5.1, URLSession moved to the FoundationNetworking module.
Import FoundationNetworking if it is available.