### PR TITLE
Make the Connection initializer non throwing

### DIFF
--- a/Sources/Examples/GitHub/GitHub.swift
+++ b/Sources/Examples/GitHub/GitHub.swift
@@ -20,8 +20,8 @@ class GitHubSession {
   
   var connection : Connection
   
-  init(tokenProvider: TokenProvider) throws{
-    connection = try Connection(provider:tokenProvider)
+  init(tokenProvider: TokenProvider) {
+    connection = Connection(provider:tokenProvider)
   }
   
   func getMe() throws {

--- a/Sources/Examples/GitHub/main.swift
+++ b/Sources/Examples/GitHub/main.swift
@@ -31,7 +31,7 @@ func main() throws {
     return
   }  
   
-  let github = try GitHubSession(tokenProvider:tokenProvider)
+  let github = GitHubSession(tokenProvider:tokenProvider)
   
   if arguments[1] == "login" {
     try tokenProvider.signIn(scopes:["user"])

--- a/Sources/Examples/Google/Google.swift
+++ b/Sources/Examples/Google/Google.swift
@@ -19,8 +19,8 @@ import OAuth2
 class GoogleSession {
   var connection : Connection
   
-  init(tokenProvider: TokenProvider) throws{
-    connection = try Connection(provider:tokenProvider)
+  init(tokenProvider: TokenProvider) {
+    connection = Connection(provider:tokenProvider)
   }
   
   func getMe() throws {

--- a/Sources/Examples/Google/main.swift
+++ b/Sources/Examples/Google/main.swift
@@ -77,7 +77,7 @@ func main() throws {
       print("Unable to create token provider.")
       return
     }
-    let google = try GoogleSession(tokenProvider:browserTokenProvider)
+    let google = GoogleSession(tokenProvider:browserTokenProvider)
 
     switch option {
     case .login:

--- a/Sources/Examples/Meetup/Meetup.swift
+++ b/Sources/Examples/Meetup/Meetup.swift
@@ -20,8 +20,8 @@ class MeetupSession {
   
   var connection : Connection
   
-  init(tokenProvider: TokenProvider) throws{
-    connection = try Connection(provider:tokenProvider)
+  init(tokenProvider: TokenProvider) {
+    connection = Connection(provider:tokenProvider)
   }
   
   func getMe() throws {

--- a/Sources/Examples/Meetup/main.swift
+++ b/Sources/Examples/Meetup/main.swift
@@ -31,7 +31,7 @@ func main() throws {
     return
   }
 
-  let meetup = try MeetupSession(tokenProvider:tokenProvider)
+  let meetup = MeetupSession(tokenProvider:tokenProvider)
   
   if arguments[1] == "login" {
     try tokenProvider.signIn(scopes:["basic", "ageless"])

--- a/Sources/Examples/Spotify/Spotify.swift
+++ b/Sources/Examples/Spotify/Spotify.swift
@@ -20,8 +20,8 @@ class SpotifySession {
   
   var connection : Connection
   
-  init(tokenProvider: TokenProvider) throws{
-    connection = try Connection(provider:tokenProvider)
+  init(tokenProvider: TokenProvider) {
+    connection = Connection(provider:tokenProvider)
   }
   
   func getUser() throws {

--- a/Sources/Examples/Spotify/main.swift
+++ b/Sources/Examples/Spotify/main.swift
@@ -31,7 +31,7 @@ func main() throws {
     return
   }
   
-  let spotify = try SpotifySession(tokenProvider:tokenProvider)
+  let spotify = SpotifySession(tokenProvider:tokenProvider)
   
   if arguments[1] == "login" {
     try tokenProvider.signIn(scopes:["playlist-read-private",

--- a/Sources/Examples/Twitter/Twitter.swift
+++ b/Sources/Examples/Twitter/Twitter.swift
@@ -19,8 +19,8 @@ import OAuth1
 class TwitterSession {
   public var connection : Connection
   
-  init(tokenProvider: TokenProvider) throws{
-    connection = try Connection(provider:tokenProvider)
+  init(tokenProvider: TokenProvider) {
+    connection = Connection(provider:tokenProvider)
   }
   
   func getTweets() throws {

--- a/Sources/Examples/Twitter/main.swift
+++ b/Sources/Examples/Twitter/main.swift
@@ -31,7 +31,7 @@ func main() throws {
     return
   }
   
-  let twitter = try TwitterSession(tokenProvider:tokenProvider)
+  let twitter = TwitterSession(tokenProvider:tokenProvider)
   
   if arguments[1] == "login" {
     try tokenProvider.signIn()

--- a/Sources/OAuth1/Connection.swift
+++ b/Sources/OAuth1/Connection.swift
@@ -23,7 +23,7 @@ public class Connection {
   
   public var provider : TokenProvider
   
-  public init(provider : TokenProvider) throws {
+  public init(provider : TokenProvider) {
     self.provider = provider
   }
   

--- a/Sources/OAuth2/Connection.swift
+++ b/Sources/OAuth2/Connection.swift
@@ -22,7 +22,7 @@ import CryptoSwift
 public class Connection {
   public var provider: TokenProvider
   
-  public init(provider: TokenProvider) throws {
+  public init(provider: TokenProvider) {
     self.provider = provider
   }
   


### PR DESCRIPTION
Also adapt all code initializing a `Connection`

There is no reason for the Connection initializer to throw anything. Removing the `throws` keeps code using the connection easier to write as it doesn't have to guard against any error.