### PR TITLE
Add iOS and tvOS support for the openURL(_ url: URL) function

### DIFF
--- a/Sources/OAuth1/BrowserTokenProvider.swift
+++ b/Sources/OAuth1/BrowserTokenProvider.swift
@@ -111,6 +111,7 @@ public class BrowserTokenProvider: TokenProvider {
     }
   }
 
+  @available(iOS 10.0, tvOS 10.0, *)
   public func signIn() throws {
     let sem = DispatchSemaphore(value: 0)
     try startServer(sem: sem)

--- a/Sources/OAuth1/openURL.swift
+++ b/Sources/OAuth1/openURL.swift
@@ -15,8 +15,11 @@
 import Foundation
 #if os(OSX)
   import Cocoa
+#elseif os(iOS) || os(tvOS)
+  import UIKit
 #endif
 
+#if !(os(iOS) || os(tvOS))
 private func shell(_ args: String...) -> Int32 {
   let task = Process()
   if #available(macOS 10.13, *) {
@@ -37,11 +40,19 @@ private func shell(_ args: String...) -> Int32 {
   task.waitUntilExit()
   return task.terminationStatus
 }
+#endif
 
+@available(iOS 10.0, tvOS 10.0, *)
 internal func openURL(_ url: URL) {
   #if os(OSX)
     if !NSWorkspace.shared.open(url) {
       print("default browser could not be opened")
+    }
+  #elseif os(iOS) || os(tvOS)
+    UIApplication.shared.open(url) { success in
+        if !success {
+            print("default browser could not be opened")
+        }
     }
   #else // Linux, tested on Ubuntu
     let status = shell("xdg-open", String(describing:url))

--- a/Sources/OAuth2/BrowserTokenProvider.swift
+++ b/Sources/OAuth2/BrowserTokenProvider.swift
@@ -156,6 +156,7 @@ public class BrowserTokenProvider: TokenProvider {
     }
   }
 
+  @available(iOS 10.0, tvOS 10.0, *)
   public func signIn(scopes: [String]) throws {
     let sem = DispatchSemaphore(value: 0)
     try startServer(sem: sem)

--- a/Sources/OAuth2/openURL.swift
+++ b/Sources/OAuth2/openURL.swift
@@ -15,8 +15,11 @@
 import Foundation
 #if os(OSX)
   import Cocoa
+#elseif os(iOS) || os(tvOS)
+  import UIKit
 #endif
 
+#if !(os(iOS) || os(tvOS))
 private func shell(_ args: String...) -> Int32 {
   let task = Process()
   if #available(macOS 10.13, *) {
@@ -37,11 +40,19 @@ private func shell(_ args: String...) -> Int32 {
   task.waitUntilExit()
   return task.terminationStatus
 }
+#endif
 
+@available(iOS 10.0, tvOS 10.0, *)
 internal func openURL(_ url: URL) {
   #if os(OSX)
     if !NSWorkspace.shared.open(url) {
       print("default browser could not be opened")
+    }
+  #elseif os(iOS) || os(tvOS)
+    UIApplication.shared.open(url) { success in
+        if !success {
+            print("default browser could not be opened")
+        }
     }
   #else // Linux, tested on Ubuntu
     let status = shell("xdg-open", String(describing:url))


### PR DESCRIPTION
Commit f3c652646735e27885e81e710d4147f33eb6c26f introduced a `shell` function that depends on the `Process` class which is not available on iOS and tvOS.

Fixes #31