### PR TITLE
Bump OS supported versions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,9 @@ import PackageDescription
 
 let package = Package(
   name: "Auth",
+  platforms: [
+    .macOS(.v10_12), .iOS(.v9), .tvOS(.v9)
+  ],
   products: [
     .library(name: "OAuth1", targets: ["OAuth1"]),
     .library(name: "OAuth2", targets: ["OAuth2"]),


### PR DESCRIPTION
An alternative solution would be to pin the Crypto version to strictly below 1.3.2

https://github.com/googleapis/google-auth-library-swift/issues/38