### PR TITLE
oauth2: BrowserTokenProvider convenience init

### DIFF
--- a/Sources/OAuth2/BrowserTokenProvider.swift
+++ b/Sources/OAuth2/BrowserTokenProvider.swift
@@ -42,7 +42,7 @@ public class BrowserTokenProvider: TokenProvider {
 
   private var sem: DispatchSemaphore?
 
-  public init?(credentials: String, token tokenfile: String) {
+  public convenience init?(credentials: String, token tokenfile: String) {
     let path = ProcessInfo.processInfo.environment["HOME"]!
       + "/.credentials/" + credentials
     let url = URL(fileURLWithPath: path)
@@ -51,9 +51,13 @@ public class BrowserTokenProvider: TokenProvider {
       print("No credentials data at \(path).")
       return nil
     }
+    self.init(credentials: credentialsData, token: tokenfile)
+  }
+
+  public init?(credentials: Data, token tokenfile: String) {
     let decoder = JSONDecoder()
     guard let credentials = try? decoder.decode(Credentials.self,
-                                                from: credentialsData)
+                                                from: credentials)
     else {
       print("Error reading credentials")
       return nil


### PR DESCRIPTION
The BrowserTokenProvider assumes files exist in the app container which
doesn't work on iOS. Allow the caller to pass the credentials as Data.

One might imagine the addition of an AuthenticationServicesTokenProvider
that uses https://developer.apple.com/documentation/authenticationservices/asauthorizationsinglesignonprovider
as the backing mechanism for macOS/iOS client apps. But that can come at
a later date. This unblocks usage on iOS and makes it easier to use on macOS
immediately.

EDIT: new token provider is in https://github.com/googleapis/google-auth-library-swift/pull/55